### PR TITLE
Adds bash files for Linux install

### DIFF
--- a/default_hudfiles/get_resources.sh
+++ b/default_hudfiles/get_resources.sh
@@ -1,0 +1,52 @@
+#!/usr/bin/env bash
+
+# Setting default delimiter to newline
+# Some paths inside the VPK contain spaces and will break the script otherwise
+SAVEIFS=$IFS
+IFS=$(echo -en "\n\b")
+
+# Setting some path variables for later use
+misc_path="../../../tf2_misc_dir.vpk"
+vpk_dir="../../../../bin"
+# Two files you need to extract separately
+hud_layout="scripts/hudlayout.res"
+hud_animations="scripts/hudanimations_tf.txt"
+
+# Find vpklinux and choose action based on 32/64bit arch
+# This should be in every TF2 Linux install's bin directory, in theory
+if [ -f "$vpk_dir/vpk_linux32" ]; then
+	if [ $(uname -m) = "x86_64" ]; then
+		# 64bit arch requires a tweak to launch vpk_linux32
+		# https://developer.valvesoftware.com/wiki/VPK#Linux_users
+		export LD_LIBRARY_PATH=$vpk_dir
+	fi
+else
+	echo "ERROR: vpk_linux32 was not located in TF2's /bin directory"
+	exit 1
+fi
+
+# Extract two files outside resource/ directory
+# Then move them outside their folder for HUD to work properly
+mkdir -p scripts
+$vpk_dir/vpk_linux32 x $misc_path $hud_layout $hud_animations
+cp -r scripts/* .
+rm -rf scripts/
+
+# Find all cases where HUD /resource/ files use /default_hudfiles/ .RES files
+# Except for cases where line begins with "/", to not catch comments
+file_list=$(find ../resource/ -type f -name "*.res" | \
+	xargs grep "^[^/]" | \
+	grep -hoP "(?<=default_hudfiles/).*(?=\")")
+# Lowercase the path names
+file_list=( "${file_list[@],,}" )
+# Sorting out repetitions
+file_list=$( echo "${file_list[@]}" | sort -u )
+
+# Now extract all of the needed base .RES files
+for file in $file_list; do
+	# Throws error if you don't create the directories first
+	file_dir=$(dirname "${file}")
+	mkdir -p $file_dir
+	# Extraction
+	$vpk_dir/vpk_linux32 x $misc_path $file
+done

--- a/linux_prep.sh
+++ b/linux_prep.sh
@@ -1,0 +1,34 @@
+#!/usr/bin/env bash
+
+# Check whether the directory containing HUD is lowercase
+# If it's not, terminate the script and notify user
+dir_name=${PWD##*/}
+if [ ! $dir_name == ${dir_name,,} ]; then
+	echo "ERROR: parent directory is uppercase. Proper ex.: wiethud"
+	exit 1
+fi
+
+# Deal with initial uppercase files before extracting anything
+# Function for checking uppercase and doing mv on matches
+# Also ignoring the HLExtract folder and files in it
+check_uppercase () {
+	if [ ! $1 == ${1,,} ]; then
+		if [ ! $(dirname $1) == "./HLExtract" ] && \
+				[ ! $(basename $1) == "HLExtract" ]; then
+			echo "lowercase $1"
+			mv $1 ${1,,}
+		fi
+	fi
+}
+
+# Do directory check first to avoid moving files to places that don't exist
+# Not very efficient, but one-liners of this are very tricky and complicated
+find . -type d | while read dir_path; do check_uppercase $dir_path; done
+find . -type f | while read file_path; do check_uppercase $file_path; done
+
+# Call the get_resources.sh script from default_hud directory for final step
+# Reason for this is how vpk_linux32 works, as it can extract only file-by-file
+# And only maintaining full folder structure, which is easier to recreate there
+# Without additional steps to further complicate the process
+cd default_hudfiles/
+/bin/bash ./get_resources.sh


### PR DESCRIPTION
Due to working with vpk_linux32 and not HLExtract, the work had to be
split across two .sh files: one in the root directory (linux_prep.sh)
and another in /default_hudfiles/ (get_resources.sh). "linux_prep"
starts with lowercasing all files and folders (except HLExtract) and
then calls get_resources, which fetches all the .res files needed from
the VPK.

Also, this somehow pulls 2 more files than there are in the main repo's
default_hudfiles: "resource/ui/econ/itemmodelpanelcollectionitem.res" 
and "resource/ui/econ/itemmodelpanel.res". Not sure if intended.